### PR TITLE
fix: Remove problematic firezone_id

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -117,7 +117,6 @@ resource "google_compute_instance_template" "application" {
       observability_log_level = var.observability_log_level
 
       firezone_token        = var.token
-      firezone_id           = var.firezone_id != null ? var.firezone_id : random_id.firezone_id.hex
       firezone_api_url      = var.api_url
       firezone_version      = var.vsn
       swap_size_gb          = var.swap_size_gb
@@ -181,10 +180,6 @@ resource "google_compute_health_check" "port" {
   lifecycle {
     create_before_destroy = true
   }
-}
-
-resource "random_id" "firezone_id" {
-  byte_length = 8
 }
 
 # Use template to deploy zonal instance group

--- a/templates/cloud-init.yaml
+++ b/templates/cloud-init.yaml
@@ -40,7 +40,7 @@ runcmd:
   # Install Firezone Gateway early to allow healthcheck to succeed.
   - |
     export FIREZONE_TOKEN="${firezone_token}"
-    export FIREZONE_ID="${firezone_id}"
+    export FIREZONE_ID="$(uuidgen)"
     export FIREZONE_API_URL="${firezone_api_url}"
     export FIREZONE_VERSION="${firezone_version}"
     export FIREZONE_ARTIFACT_URL="${firezone_artifact_url}"

--- a/variables.tf
+++ b/variables.tf
@@ -111,12 +111,6 @@ variable "vsn" {
   description = "Version of the Firezone gateway that is downloaded from `artifact_url`."
 }
 
-variable "firezone_id" {
-  type        = string
-  default     = null
-  description = "Optionally override the FIREZONE_ID variable to identify the gateway in the admin portal. Defaults to a random string."
-}
-
 variable "health_check" {
   type = object({
     name     = string


### PR DESCRIPTION
This variable needs to be unique per gateway, and Google instance group managers don't provide an easy way to do that.

So we simply generate it per-instance when provisioning the Gateway, similar to the other Terraform modules.

Persistent, yet unique, firezone_id's will be saved for a future iteration. See https://github.com/firezone/terraform-google-gateway/issues/3