### PR TITLE
feat: Use GVNIC as nic_type and set queue_count=2

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -67,9 +67,10 @@ resource "google_compute_instance_template" "application" {
   }
 
   network_interface {
-    subnetwork = var.compute_subnetwork
-
-    stack_type = "IPV4_IPV6"
+    subnetwork  = var.compute_subnetwork
+    nic_type    = "GVNIC"
+    queue_count = var.queue_count
+    stack_type  = "IPV4_IPV6"
 
     dynamic "ipv6_access_config" {
       for_each = var.compute_provision_public_ipv6_address == true ? [true] : []

--- a/variables.tf
+++ b/variables.tf
@@ -51,6 +51,27 @@ variable "swap_size_gb" {
   description = "Size of the swap partition in GB. Default is 0, or disabled."
 }
 
+variable "queue_count" {
+  type        = number
+  default     = 2
+  description = "Number of max RX / TX queues to assign to the NIC."
+
+  validation {
+    condition     = var.queue_count >= 2
+    error_message = "queue_count must be greater than or equal to 2."
+  }
+
+  validation {
+    condition     = var.queue_count % 2 == 0
+    error_message = "queue_count must be an even number."
+  }
+
+  validation {
+    condition     = var.queue_count <= 16
+    error_message = "queue_count must be less than or equal to 16."
+  }
+}
+
 ################################################################################
 ## Observability
 ################################################################################


### PR DESCRIPTION
`GVNIC` can have improved performance on shared vCPU systems like `e2-micro`, and should be a safe default since it's available on every VM type.

https://cloud.google.com/compute/docs/networking/using-gvnic

`queue_count` sets the number of `RX / TX` queues and should generally equal the number of CPU cores. Since virtually all GCP VMs have 2 or more cores, `2` is a good default here.