### PR TITLE
fix: use dynamic port allocation

### DIFF
--- a/examples/nat-gateway/network.tf
+++ b/examples/nat-gateway/network.tf
@@ -45,7 +45,7 @@ resource "google_compute_router_nat" "firezone" {
   # this gateway.
   enable_dynamic_port_allocation = true
   min_ports_per_vm               = 64
-  max_ports_per_vm               = 65536
+  max_ports_per_vm               = 32768
 
   nat_ip_allocate_option = "MANUAL_ONLY"
   nat_ips = [

--- a/examples/nat-gateway/network.tf
+++ b/examples/nat-gateway/network.tf
@@ -40,6 +40,13 @@ resource "google_compute_router_nat" "firezone" {
   name   = "firezone-gateway-nat"
   router = google_compute_router.firezone.name
 
+  # The default here is static, and only 64 ports per VM, which will cause issues
+  # if more than 64 clients are connecting to the same public resource behind
+  # this gateway.
+  enable_dynamic_port_allocation = true
+  min_ports_per_vm               = 64
+  max_ports_per_vm               = 65536
+
   nat_ip_allocate_option = "MANUAL_ONLY"
   nat_ips = [
     google_compute_address.ipv4.self_link,


### PR DESCRIPTION
The Cloud NAT gateway on Google used in this module specifies a default configuration of static port allocation and 64 minimum ports per VM.

This means the Firezone gateway will only be able to establish 64 unique UDP and TCP connections to the same destination address.

To fix this, we should default to dynamic port allocation here which will start with the min and allow growing up the max defined here.